### PR TITLE
Generalize code to remove "siggen"

### DIFF
--- a/siggen/cmd_signify.py
+++ b/siggen/cmd_signify.py
@@ -8,7 +8,7 @@ import argparse
 import json
 import sys
 
-from siggen.generator import SignatureGenerator
+from .generator import SignatureGenerator
 
 
 DESCRIPTION = """

--- a/siggen/generator.py
+++ b/siggen/generator.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from siggen.rules import (
+from .rules import (
     SignatureGenerationRule,
     StackwalkerErrorSignatureRule,
     OOMSignature,

--- a/siggen/tests/test_siglists.py
+++ b/siggen/tests/test_siglists.py
@@ -2,11 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import importlib
+
 import mock
 from pkg_resources import resource_stream
 import pytest
 
-from siggen import siglists_utils
+# NOTE(willkg): We do this so that we can extract signature generation into its
+# own namespace as an external library. This allows the tests to run if it's in
+# "siggen" or "socorro.signature".
+base_module = '.'.join(__name__.split('.')[:-2])
+siglists_utils = importlib.import_module(base_module + '.siglists_utils')
 
 
 def _fake_stream(pkg, filepath):
@@ -31,7 +37,7 @@ class TestSigLists:
                 if isinstance(line, basestring):
                     assert not line.startswith('#')
 
-    @mock.patch('siggen.siglists_utils.resource_stream')
+    @mock.patch(base_module + '.siglists_utils.resource_stream')
     def test_valid_entries(self, mocked_stream):
         mocked_stream.side_effect = _fake_stream
 
@@ -43,7 +49,7 @@ class TestSigLists:
         content = siglists_utils._get_file_content('test-valid-sig-list')
         assert content == expected
 
-    @mock.patch('siggen.siglists_utils.resource_stream')
+    @mock.patch(base_module + '.siglists_utils.resource_stream')
     def test_invalid_entry(self, mocked_stream):
         mocked_stream.side_effect = _fake_stream
 

--- a/siggen/tests/test_signature_generator.py
+++ b/siggen/tests/test_signature_generator.py
@@ -2,13 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from siggen.generator import SignatureGenerator
+import importlib
+
+# NOTE(willkg): We do this so that we can extract signature generation into its
+# own namespace as an external library. This allows the tests to run if it's in
+# "siggen" or "socorro.signature".
+base_module = '.'.join(__name__.split('.')[:-2])
+generator = importlib.import_module(base_module + '.generator')
 
 
 class TestSignatureGenerator:
     def test_empty_dicts(self):
-        generator = SignatureGenerator()
-        ret = generator.generate({})
+        generator_obj = generator.SignatureGenerator()
+        ret = generator_obj.generate({})
 
         # NOTE(willkg): This is what the current pipeline yields. If any of those parts change, this
         # might change, too. The point of this test is that we can pass in empty dicts and the
@@ -27,8 +33,8 @@ class TestSignatureGenerator:
         class BadRule(object):
             pass
 
-        generator = SignatureGenerator(pipeline=[BadRule()])
-        ret = generator.generate({})
+        generator_obj = generator.SignatureGenerator(pipeline=[BadRule()])
+        ret = generator_obj.generate({})
 
         expected = {
             'notes': [


### PR DESCRIPTION
At some point, we want to unfork the signature generation code and thus
the code will exist in two different Python modules. This fixes
everything so that it can do that nicely.