### PR TITLE
Fix CI to run tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,19 +24,10 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install CI dependencies
+    - name: Update pip and install tox
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip install tox
 
-    - name: Lint
-      run: flake8
-
-    - name: Run tests
-      run: pytest
-
-    - name: Test commands
-      run: |
-        signify --help
-        fetch-data --help
-        signature --help
+    - name: Tox
+      run: tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -e .
 
-pytest
-mock
-flake8
-pytest-wholenodeid
-check-manifest
-twine
-wheel
+check-manifest==0.39
+flake8==3.7.8
+mock==3.0.5
+pytest==5.2.0
+tox==3.14.0
+twine==2.0.0 ; python_version >= '3.6'
+wheel==0.33.6

--- a/siggen/rules.py
+++ b/siggen/rules.py
@@ -205,7 +205,7 @@ class CSignatureTool(SignatureTool):
         module_offset=None,
         offset=None,
         normalized=None,
-        **kwargs,  # eat any extra kwargs passed in
+        **kwargs  # eat any extra kwargs passed in
     ):
         """Normalizes a single frame
 


### PR DESCRIPTION
This reworks the CI configuration to run tox so it runs all the things in all the supported Python environments.

This also fixes a syntax issue with Python 3.5.