### PR TITLE
remove unneeded dependencies (#80)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,11 @@
 ---
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: main
+
+  pull_request:
 
 jobs:
   build:
@@ -23,10 +27,29 @@ jobs:
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
-          pip install '.[dev]'
+          pip install '.[cli,dev]'
 
       - name: Lint
         run: make lint
 
       - name: Test
         run: tox
+
+  norequests:
+    name: Python 3.9 with no requests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.5
+
+      - name: Set up Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.9
+
+      - name: Update pip and install dev requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Run commands with no requests
+        run: ./bin/run_cmd_tests.sh --no-requests

--- a/README.rst
+++ b/README.rst
@@ -17,13 +17,17 @@ Installing
 ==========
 
 socorro-siggen is available on `PyPI <https://pypi.org/project/siggen/>`_. You
-can install it with::
+can install for library usage with::
 
     $ pip install siggen
 
+You can install for cli usage with::
+
+    $ pip install 'siggen[cli]'
+
 Install for hacking::
 
-    $ pip install -e '.[dev]'
+    $ pip install -e '.[cli,dev]'
 
 
 Basic use

--- a/README.rst
+++ b/README.rst
@@ -274,7 +274,10 @@ Release process
    2. Run tests: ``make test``
 
 6. Push the branch, create a PR, review it, merge it.
-7. Create a signed tag, push to github::
+
+7. Check out and update main branch locally.
+
+8. Tag the release::
 
      git tag -s v0.1.0
 

--- a/bin/run_cmd_tests.sh
+++ b/bin/run_cmd_tests.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Runs commands and spits out help text.
+
+# Usage: bin/run_cmd_tests.sh [--non-zero-exit]
+
 set -e
 
 signify --help
-fetch-data --help
-signature --help
+
+if [[ "$1" == "--no-requests" ]]; then
+    fetch-data --help && /bin/false || /bin/true
+    signature --help && /bin/false || /bin/true
+
+else
+    fetch-data --help
+    signature --help
+fi

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,11 @@ def get_version():
 
 INSTALL_REQUIRES = [
     "glom",
-    "requests",
 ]
 EXTRAS_REQUIRE = {
+    "cli": [
+        "requests<3",
+    ],
     "dev": [
         "check-manifest==0.47",
         "flake8==4.0.1",

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ def get_version():
 INSTALL_REQUIRES = [
     "glom",
     "requests",
-    "six",
-    "ujson",
 ]
 EXTRAS_REQUIRE = {
     "dev": [

--- a/siggen/cmd_fetch_data.py
+++ b/siggen/cmd_fetch_data.py
@@ -9,7 +9,12 @@ import json
 import os
 import sys
 
-import requests
+try:
+    import requests
+except ImportError:
+    print("Error importing requests. You need to install the cli extras.", file=sys.stderr)
+    print("Try: pip install 'siggen[cli]'", file=sys.stderr)
+    sys.exit(1)
 
 from .utils import convert_to_crash_data
 
@@ -41,6 +46,11 @@ class WrappedTextHelpFormatter(argparse.HelpFormatter):
         return "\n\n".join(parts)
 
 
+def printerr(s, **kwargs):
+    kwargs["file"] = sys.stderr
+    print(s, **kwargs)
+
+
 DESCRIPTION = """
 Takes a crash id via the command line, pulls down the crash information, and
 outputs JSON for signature generation.
@@ -51,11 +61,6 @@ set SOCORRO_API_TOKEN in the environment.
 
 # FIXME(willkg): This hits production. We might want it configurable.
 API_URL = "https://crash-stats.mozilla.org/api"
-
-
-def printerr(s, **kwargs):
-    kwargs["file"] = sys.stderr
-    print(s, **kwargs)
 
 
 def fetch(endpoint, crash_id, api_token=None):

--- a/siggen/cmd_signature.py
+++ b/siggen/cmd_signature.py
@@ -7,7 +7,12 @@ import csv
 import os
 import sys
 
-import requests
+try:
+    import requests
+except ImportError:
+    print("Error importing requests. You need to install the cli extras.", file=sys.stderr)
+    print("Try: pip install 'siggen[cli]'", file=sys.stderr)
+    sys.exit(1)
 
 from .generator import SignatureGenerator
 from .utils import convert_to_crash_data, parse_crashid

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py39-norequests
 
 [gh-actions]
 python =
@@ -13,6 +13,10 @@ install_command = pip install {packages}
 extras = dev
 commands = 
     pytest
-    signify --help
-    fetch-data --help
-    signature --help
+    {toxinidir}/bin/run_cmd_tests.sh
+
+[testenv:py39-norequests]
+install_command = pip install {packages}
+extras =
+commands =
+    {toxinidir}/bin/run_cmd_tests.sh --no-requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py39-norequests
+envlist = py37,py38,py39,py310
 
 [gh-actions]
 python =
@@ -14,9 +14,3 @@ extras = dev
 commands = 
     pytest
     {toxinidir}/bin/run_cmd_tests.sh
-
-[testenv:py39-norequests]
-install_command = pip install {packages}
-extras =
-commands =
-    {toxinidir}/bin/run_cmd_tests.sh --no-requests


### PR DESCRIPTION
This removes ujson and six as dependencies. They aren't used.

This also makes the requests dependency optional by putting it in the cli extras. You only need to install it if you're using the commands installed. I tweaked the commands to print out a helpful error if requests isn't installed when you try to use them. I also added a tox test for that.