### PR TITLE
Release updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,29 +27,7 @@ jobs:
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
-          pip install '.[cli,dev]'
+          pip install -r requirements-dev.txt
 
-      - name: Lint
-        run: make lint
-
-      - name: Test
+      - name: Tox
         run: tox
-
-  norequests:
-    name: Python 3.9 with no requests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.5
-
-      - name: Set up Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.9
-
-      - name: Update pip and install dev requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-
-      - name: Run commands with no requests
-        run: ./bin/run_cmd_tests.sh --no-requests

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,16 +2,30 @@
 History
 =======
 
+1.0.20220802 (In development)
+=============================
+
+FIXME: update date when released
+
+Bug fixes:
+
+* Removed ``siggen.__releasedate__``. We'll include the date in the versions going
+  forward.
+* Moved dev requirements into ``requirements-dev.txt`` file.
+
+
 1.0.9 (August 2nd, 2022)
 ========================
 
 Bug fixes:
 
-* bug 1764570: update to fillmore 0.1.1; drop capture_error
-* Bug 1777954 - Adjust regular expressions matching Android, Linux and macOS libraries that changed
+* bug 1764570: update to fillmore 0.1.1; drop ``capture_error``
+* Bug 1777954 - Adjust regular expressions matching Android, Linux and macOS
+  libraries that changed
 * Bug 1777954 - Removed obsolete entries in the prefix and irrelevant lists
-* Bug 1777954 - Reorganize signatures containing implementations of common library functions
-* bug 1774110: add mozilla::dom::AutoJSAPI::Init to prefix list
+* Bug 1777954 - Reorganize signatures containing implementations of common
+  library functions
+* bug 1774110: add ``mozilla::dom::AutoJSAPI::Init`` to prefix list
 * bug 1767279: fix license headers in python files
 
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ You can install for cli usage with::
 
 Install for hacking::
 
-    $ pip install -e '.[cli,dev]'
+    $ pip install -r requirements-dev.txt
 
 
 Basic use
@@ -252,47 +252,3 @@ That produces this output::
       "proto_signature": "SomeFunc | SomeOtherFunc",
       "signature": "SomeFunc"
     }
-
-
-Release process
-===============
-
-1. Create branch from main tip.
-2. Check to make sure ``setup.py`` has updated versions of things.
-
-   Update dev dependencies: ``make checkrot``
-
-3. Update version and release date in ``siggen/__init__.py``.
-
-   1. Set ``__version__`` to something like ``1.0.0`` (use semver).
-   2. Set ``__releasedate__`` to something like ``20211018``.
-
-4. Update ``HISTORY.rst``.
-
-   1. Set the date for the release.
-   2. Make sure to note any backwards incompatible changes.
-
-5. Verify correctness.
-
-   1. Check manifest: ``check-manifest``
-   2. Run tests: ``make test``
-
-6. Push the branch, create a PR, review it, merge it.
-
-7. Check out and update main branch locally.
-
-8. Tag the release::
-
-     git tag -s v0.1.0
-
-   Copy details from ``HISTORY.rst`` into tag comment.
-
-8. Update PyPI::
-
-     rm -rf dist/*
-     python setup.py sdist bdist_wheel
-     twine upload dist/*
-
-9. Push everything::
-
-     git push --tags origin main

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# Requirements for development
+-e .[cli]
+check-manifest==0.48
+build==0.8.0
+flake8==5.0.3
+pytest==7.1.2
+tox==3.25.1
+tox-gh-actions==2.9.1
+twine==4.0.1
+wheel==0.37.1

--- a/setup.py
+++ b/setup.py
@@ -29,15 +29,6 @@ EXTRAS_REQUIRE = {
     "cli": [
         "requests<3",
     ],
-    "dev": [
-        "check-manifest==0.48",
-        "flake8==4.0.1",
-        "pytest==7.1.2",
-        "tox==3.25.0",
-        "tox-gh-actions==2.9.1",
-        "twine==4.0.0",
-        "wheel==0.37.1",
-    ],
 }
 
 

--- a/siggen/__init__.py
+++ b/siggen/__init__.py
@@ -3,8 +3,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-# yyyymmdd
-__releasedate__ = "20220802"
-
-# x.y.z or x.y.z.dev0 -- semver
-__version__ = "1.0.9"
+# x.y.YYYYMMDD or x.y.YYYYMMDD.dev0 -- semver
+__version__ = "1.0.20220802"

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,26 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py39-flake8,py39-norequests
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
-    3.9: py39
+    3.9: py39, py39-flake8, py39-norequests
     3.10: py310
 
 [testenv]
-install_command = pip install {packages}
-extras = dev
+deps = -rrequirements-dev.txt
 commands = 
     pytest
     {toxinidir}/bin/run_cmd_tests.sh
+
+[testenv:py39-flake8]
+deps = -rrequirements-dev.txt
+commands =
+    flake8 siggen
+
+[testenv:py39-norequests]
+deps =
+install_command = pip install {packages}
+commands =
+    {toxinidir}/bin/run_cmd_tests.sh --no-requests


### PR DESCRIPTION
This moves dev requirements to requirements-dev.txt. It's a little easier to maintain them there.

This changes the versioning schema to x.y.YYYYMMDD which makes it easier to infer the last time this was updated from the version number. That's really helpful when you're trying to keep the lists updated.