### PR TITLE
Merge 20240412

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version():
 
 INSTALL_REQUIRES = [
     "glom",
-    "importlib_resources",
+    "importlib_resources;python_version<'3.9'",
 ]
 EXTRAS_REQUIRE = {
     "cli": [

--- a/siggen/siglists/irrelevant_signature_re.txt
+++ b/siggen/siglists/irrelevant_signature_re.txt
@@ -109,6 +109,7 @@ __memmove
 __memset
 mnt@asec@org\.mozilla\.f.*\.apk@classes\.dex@0x
 MOZ_Crash
+mozalloc_abort
 mozalloc_handle_oom
 mozglue_static::oom_hook::hook
 mozglue_static::panic_hook
@@ -135,6 +136,7 @@ mozilla::ipc::WriteIPDLParam
 mozilla::HashMap
 mozilla::HashSet
 mozilla::MediaRawData::Data
+mozilla::Monitor::Lock
 mozilla::Monitor::Wait
 mozilla::MozPromiseHolderBase
 mozilla::MozPromiseRefcountable::Release
@@ -164,12 +166,17 @@ mozilla::ThreadSafeAutoRefCnt
 mozilla::UniquePtr
 mozilla::widget::WlCrashHandler
 mozilla::wr::RenderThread::AddRef
-nsCOMPtr<T>::~nsCOMPtr
+moz_xmalloc
+moz_xrealloc
+nsCOMPtr<T>::
 nsCOMPtr_base::~nsCOMPtr_base
+nsMaybeWeakPtr<T>::
 nsQueryObject<T>::operator
 nsRunnableMethodReceiver<T>::nsRunnableMethodReceiver
 ns.*Hashtable
 nsTArrayElementTraits
+nsTArrayInfallibleAllocator
+nsTArray_base<
 nsThread::GetEvent
 nsThread::ProcessNextEvent
 NS_ProcessNextEvent

--- a/siggen/siglists/prefix_signature_re.txt
+++ b/siggen/siglists/prefix_signature_re.txt
@@ -33,6 +33,8 @@ core::option::expect_none_failed
 core::ptr::drop_in_place
 core::ptr::real_drop_in_place
 core::result::unwrap_failed
+<core::ops::range::Range<usize> as core::slice::index::SliceIndex<\[T\]>>::index
+core::slice::index::<impl core::ops::index::Index<I> for \[T\]>::index
 core::str::slice_error_fail
 CreateFileMappingA
 __cxxabiv1::failed_throw
@@ -65,6 +67,7 @@ hashbrown::raw::Fallibility::alloc_err
 hashbrown::raw::RawTable<T>::new_uninitialized<T>
 HeapFree
 huge_dalloc
+InfallibleAllocPolicy
 InvalidArrayIndex_CRASH
 invalid_parameter_noinfo
 _invalid_parameter_noinfo
@@ -92,8 +95,6 @@ memmove
 memset
 MessageLoop::PostTask_Helper
 MessageLoop::PostTask
-mozalloc_abort
-mozalloc_handle_oom
 moz_malloc_size_of
 mozilla::CheckCheckedUnsafePtrs<T>::Check
 mozilla::CheckedInt
@@ -125,10 +126,9 @@ mozilla::ipc::IProtocol::ChannelSend
 mozilla::ipc::IToplevelProtocol::ShmemCreated
 mozilla::layers::CompositorD3D11::Failed
 mozilla::SpinEventLoopUntil
+mozilla::Vector<T>
 mozilla::WrapNotNull<
 mozilla.*FatalError
-moz_xmalloc
-moz_xrealloc
 MOZ_CrashPrintf
 msvcr120\.dll@0x
 \<name omitted\>
@@ -139,13 +139,13 @@ NS_CycleCollectorSuspect3
 -\[NSApplication _crashOnException:\]
 nsCRT::strcmp
 -\[NSObject doesNotRecognizeSelector:\]
-nsTArrayInfallibleAllocator
 NS_strcmp
 NS_strlen
 nsCOMPtr
 NS_ABORT_OOM
 NS_DebugBreak
 nsDebugImpl::Abort
+nsDocShell::GetBrowsingContext
 nsINode::GetParentNode
 nsThread::GetEvent
 [-+]\[NSException raise(:format:(arguments:)?)?\]
@@ -157,7 +157,6 @@ NSS
 nss
 nsStringBuffer::
 nsTArray<
-nsTArray_base<
 nsTArray_Impl<
 nsThread::Shutdown
 NtUser
@@ -172,6 +171,7 @@ o_strcat_s
 <.*>::operator()
 pages_commit
 PL_
+<\.plt ELF section in .*>
 port_
 PORT_
 _PR_

--- a/siggen/siglists_utils.py
+++ b/siggen/siglists_utils.py
@@ -5,7 +5,11 @@
 from pathlib import Path
 import re
 
-import importlib_resources
+# Use importlib_resources if it's there. Otherwise use the built-in version.
+try:
+    import importlib_resources
+except ImportError:
+    from importlib import resources as importlib_resources
 
 
 # This is a hack because sentinels can be a tuple, with the second item being

--- a/siggen/socorro_sha.txt
+++ b/siggen/socorro_sha.txt
@@ -1,1 +1,1 @@
-01c34878d79e24ffd1fff7d0fadca90df0b7bb89
+2edf2158a00f0dfc58cc542a5beeceb03b2ce954

--- a/siggen/utils.py
+++ b/siggen/utils.py
@@ -6,7 +6,7 @@
 import contextlib
 import copy
 import re
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from glom import glom, assign
 
@@ -411,7 +411,7 @@ def parse_crashid(item):
         return item[3:]
 
     if item.startswith("http"):
-        parsed = urlparse(item)
+        parsed = urlsplit(item)
         path = parsed.path
         if path.startswith("/report/index"):
             crash_id = path.split("/")[-1]


### PR DESCRIPTION
```
Dest sha:   01c34878d79e24ffd1fff7d0fadca90df0b7bb89
Source sha: 2edf2158a00f0dfc58cc542a5beeceb03b2ce954

2edf2158a Reverse preference for importlib_resources
f457af181 bug-1889120: add Rust sub-slice access frames to prefix signature list
f95104fa5 Bug 1885351 - Add nsCOMPtr<T>:: and nsMaybeWeakPtr<T>:: to the irrelevant signature list.
523d290b9 Bug 1884689 - Add nsDocShell::GetBrowsingContext to the prefix list.
84f34a436 Bug 1882088 - Move nsTArray OOM things to the irrelevant list.
f7605ef34 bug-1850981: update to python 3.11
7bc37bc98 bug-1876623: Treat `<.plt ELF section...>` as prefix signature (#6519)
70b98b152 bug-1799125: switch from urllib.parse's urlparse to urlsplit (#6508)
5d4705494 Bug 1866857 - Ignore mozilla::Monitor::Lock when generating crash signatures
4dc24940d Bug 1862460 - Add mozilla::Vector<T> to the prefix list.
```